### PR TITLE
Remove Agent Subscription Fee, Add Deregistration & Admin Management

### DIFF
--- a/contract/contracts/AgentManager.sol
+++ b/contract/contracts/AgentManager.sol
@@ -5,89 +5,117 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title AgentManager
- * @dev Contract for managing audit agents registration and subscription
- * @notice This contract handles agent registration, subscription management and validation
+ * @dev Contract for managing audit agents registration with suspension capability
+ * @notice This contract handles agent registration, suspension and reactivation of agent
  */
 contract AgentManager is Ownable {
     struct Agent {
         bool isRegistered;
-        uint256 subscriptionExpiry;
+        bool isActive;
     }
 
     // State variables
-    uint256 public subscriptionFee; // in Wei
-    uint256 public subscriptionDuration; // in seconds
     mapping(address => Agent) public agents;
+    mapping(address => bool) public admins;
 
     // Events
-    event AgentRegistered(address indexed agent, uint256 subscriptionExpiry);
-    event SubscriptionRenewed(address indexed agent, uint256 newExpiry);
-    event SubscriptionFeeUpdated(uint256 newFee);
-    event SubscriptionDurationUpdated(uint256 newDuration);
+    event AgentRegistered(address indexed agent);
+    event AgentDeregistered(address indexed agent);
+    event AgentSuspended(address indexed agent);
+    event AgentReactivated(address indexed agent);
+    event AdminAdded(address indexed admin);
+    event AdminRemoved(address indexed admin);
+
+    /**
+     * @dev Modifier to make a function callable only by admin accounts.
+     * Reverts with "Not authorized" if the caller is not an admin.
+     */
+    modifier onlyAdmin() {
+        require(admins[msg.sender], "Not authorized");
+        _;
+    }
 
     /**
      * @dev Constructor to initialize the contract with subscription parameters
-     * @param _subscriptionFee Fee in Wei required for agent registration
-     * @param _subscriptionDuration Duration in seconds for subscription validity
      */
-    constructor(uint256 _subscriptionFee, uint256 _subscriptionDuration) Ownable(msg.sender) {
-        subscriptionFee = _subscriptionFee;
-        subscriptionDuration = _subscriptionDuration;
+    constructor() Ownable(msg.sender) {
+        admins[msg.sender] = true; // Set deployer as initial admin
+        emit AdminAdded(msg.sender);
     }
 
     /**
-     * @dev Register a new agent with subscription fee
-     * @notice Agents must pay the subscription fee to register
+     * @dev Add a new admin
+     * @param _admin Address of the new admin
+     * @notice Only owner can add admins
+     */
+    function addAdmin(address _admin) external onlyOwner {
+        require(!admins[_admin], "Already an admin");
+        admins[_admin] = true;
+        emit AdminAdded(_admin);
+    }
+
+    /**
+     * @dev Remove an admin
+     * @param _admin Address of the admin to remove
+     * @notice Only owner can remove admins
+     */
+    function removeAdmin(address _admin) external onlyOwner {
+        require(admins[_admin], "Not an admin");
+        admins[_admin] = false;
+        emit AdminRemoved(_admin);
+    }
+
+    /**
+     * @dev Register a new agent.
      */
     function registerAgent() external payable {
-        require(msg.value == subscriptionFee, "Invalid subscription fee");
         require(!agents[msg.sender].isRegistered, "Agent already registered");
 
-        agents[msg.sender] = Agent({
-            isRegistered: true,
-            subscriptionExpiry: block.timestamp + subscriptionDuration
-        });
+        agents[msg.sender] = Agent(true, true);
 
-        emit AgentRegistered(msg.sender, block.timestamp + subscriptionDuration);
+        emit AgentRegistered(msg.sender);
     }
 
     /**
-     * @dev Renew subscription for an existing agent
-     * @notice Only registered agents can renew their subscription
+     * @dev Deregister an agent
+     * @notice Only registered agents can deregister
      */
-    function renewSubscription() external payable {
-        require(agents[msg.sender].isRegistered, "Agent not registered");
-        require(msg.value == subscriptionFee, "Invalid subscription fee");
-
-        agents[msg.sender].subscriptionExpiry = block.timestamp + subscriptionDuration;
-
-        emit SubscriptionRenewed(msg.sender, block.timestamp + subscriptionDuration);
+    function deregisterAgent() external {
+        require(agents[msg.sender].isRegistered, "Not registered");
+        delete agents[msg.sender];
+        emit AgentDeregistered(msg.sender);
     }
 
     /**
-     * @dev Check if an agent is registered and has valid subscription
+     * @dev Suspend an agent for abuse
+     * @param _agent Address of the agent to suspend
+     * @notice Only admins can suspend an agent
+     */
+    function suspendAgent(address _agent) external onlyAdmin {
+        require(agents[_agent].isRegistered, "Agent not registered");
+        require(agents[_agent].isActive, "Agent already suspended");
+        agents[_agent].isActive = false;
+        emit AgentSuspended(_agent);
+    }
+
+    /**
+     * @dev Reactivate a suspended agent
+     * @param _agent Address of the agent to reactivate
+     * @notice Only admins can reactivate an agent
+     */
+    function reactivateAgent(address _agent) external onlyAdmin {
+        require(agents[_agent].isRegistered, "Agent not registered");
+        require(!agents[_agent].isActive, "Agent already active");
+        agents[_agent].isActive = true;
+        emit AgentReactivated(_agent);
+    }
+
+    /**
+     * @dev Check if an agent is registered and not suspended
      * @param _agent Address of the agent to check
-     * @return bool True if agent is registered and subscription is valid
+     * @return bool True if agent is registered and active
      */
     function isValidAgent(address _agent) external view returns (bool) {
-        return agents[_agent].isRegistered && agents[_agent].subscriptionExpiry > block.timestamp;
-    }
-
-    /**
-     * @dev Update subscription fee (only owner)
-     * @param _newFee New subscription fee in Wei
-     */
-    function updateSubscriptionFee(uint256 _newFee) external onlyOwner {
-        subscriptionFee = _newFee;
-        emit SubscriptionFeeUpdated(_newFee);
-    }
-
-    /**
-     * @dev Update subscription duration (only owner)
-     * @param _newDuration New subscription duration in seconds
-     */
-    function updateSubscriptionDuration(uint256 _newDuration) external onlyOwner {
-        subscriptionDuration = _newDuration;
-        emit SubscriptionDurationUpdated(_newDuration);
+        return agents[_agent].isRegistered && agents[_agent].isActive;
     }
 }

--- a/contract/contracts/AgentManager.sol
+++ b/contract/contracts/AgentManager.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * @title AgentManager
  * @dev Contract for managing audit agents registration with suspension capability
  * @notice This contract handles agent registration, suspension and reactivation of agent
+ * TODO: Make contract upgradeable, add reentrancy protection
  */
 contract AgentManager is Ownable {
     struct Agent {


### PR DESCRIPTION
1. Subscription Fee Update: As per the Kyoto group sync discussion, the subscription fee for agents has been removed from the Agent Manager contracts. Instead, sponsors/Bounty creators will bear this cost.

2. Deregistration Function: Implemented `deregisterAgent()` function as per the updated design POC.

3. Admin Management:
- Added functions to add/remove admins.
- Admins now have the ability to suspend/reactivate agents if they engage in suspicious activities.